### PR TITLE
randomize tree animation & behavior

### DIFF
--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -132,7 +132,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
     }
     
     // Creates a copy of the palm tree and randomizes the animation & rotation
-    func createPalmTree(position : SCNVector3, maxScale : Float, minScale: Float, maxDelay: Double?) {
+    func createPalmTree(position : SCNVector3, maxScale : Float, minScale: Float, maxDelay: Double) {
         let allTrees = [palmNodes, pineNodes, treeNodes, trunkNodes]
         let randTypeIndex = arc4random_uniform(UInt32(allTrees.count))
         let randType = allTrees[Int(randTypeIndex)]
@@ -156,28 +156,16 @@ class ViewController: UIViewController, ARSCNViewDelegate {
 
         var delaySequence : SCNAction
         var palmSequence : SCNAction
-        
-        // If a delay amount has been passed, delay the sequence from starting. Otherwise, play normal sequence right away
-        if let maxDelayAmt = maxDelay {
-            // Randomize the delay to create an organic forest growth animation
-            let delayAmt = drand48() * maxDelayAmt
-            delaySequence = SCNAction.wait(duration: delayAmt)
-            palmSequence = SCNAction.sequence([
-                    delaySequence,
-                    playSound,
-                    growPalmAction,
-                    shrinkPalmAction,
-                    SCNAction.removeFromParentNode()
-                ])!
-        } else {
-            palmSequence = SCNAction.sequence([
-                    playSound,
-                    growPalmAction,
-                    shrinkPalmAction,
-                    SCNAction.removeFromParentNode()
-                ])!
-        }
-        
+
+        let delayAmt = drand48() * maxDelay
+        delaySequence = SCNAction.wait(duration: delayAmt)
+        palmSequence = SCNAction.sequence([
+                delaySequence,
+                playSound,
+                growPalmAction,
+                shrinkPalmAction,
+                SCNAction.removeFromParentNode()
+            ])!
         palmClone.runAction(palmSequence)
         
         // Set position of palm tree to position passed through parameter

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -133,8 +133,6 @@ class ViewController: UIViewController, ARSCNViewDelegate {
     
     // Creates a copy of the palm tree and randomizes the animation & rotation
     func createPalmTree(position : SCNVector3, maxScale : Float, minScale: Float, maxDelay: Double?) {
-        // TODO: Randomize the palm tree's vertical rotation and the scale the trees grow to
-        
         let allTrees = [palmNodes, pineNodes, treeNodes, trunkNodes]
         let randTypeIndex = arc4random_uniform(UInt32(allTrees.count))
         let randType = allTrees[Int(randTypeIndex)]
@@ -142,9 +140,6 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         let randNode = randType[Int(randNodeIndex)]
         
         let palmClone = randNode!.clone()
-        
-        // Rotate the palm tree to be upright
-        // palmClone.rotation = SCNVector4Make(-1, 0, 0, Float(Double.pi / 2))
         
         // Set scale of tree to 0
         palmClone.scale = SCNVector3Make(0, 0, 0)
@@ -161,6 +156,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         
         // If a delay amount has been passed, delay the sequence from starting. Otherwise, play normal sequence right away
         if let maxDelayAmt = maxDelay {
+            // Randomize the delay to create an organic forest growth animation
             let delayAmt = drand48() * maxDelayAmt
             delaySequence = SCNAction.wait(duration: delayAmt)
             palmSequence = SCNAction.sequence([

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -148,7 +148,10 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         let audioSource = SCNAudioSource(fileNamed: "art.scnassets/tree_sound.mp3")
         let playSound = SCNAction.playAudio(audioSource!, waitForCompletion: false)
         
-        let growPalmAction = SCNAction.scale(to: 0.3, duration: 0.5)
+        // Calculate a random scale between the provided min and max scale
+        let scaleAmt = CGFloat(drand48()) * CGFloat(maxScale - minScale) + CGFloat(minScale)
+        
+        let growPalmAction = SCNAction.scale(to: scaleAmt, duration: 0.5)
         let shrinkPalmAction = SCNAction.scale(to: 0, duration: 1.5)
 
         var delaySequence : SCNAction

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -160,13 +160,26 @@ class ViewController: UIViewController, ARSCNViewDelegate {
 
         let delayAmt = drand48() * maxDelay
         delaySequence = SCNAction.wait(duration: delayAmt)
-        palmSequence = SCNAction.sequence([
+        
+        // Randomize deletion (some elements won't be deleted after growing)
+        let deletionChance = 0.67
+        
+        if (drand48() < deletionChance) {
+            palmSequence = SCNAction.sequence([
                 delaySequence,
                 playSound,
                 growPalmAction,
                 shrinkPalmAction,
                 SCNAction.removeFromParentNode()
-            ])!
+                ])!
+        } else {
+            palmSequence = SCNAction.sequence([
+                delaySequence,
+                playSound,
+                growPalmAction
+                ])!
+        }
+        
         palmClone.runAction(palmSequence)
         
         // Set position of palm tree to position passed through parameter

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -127,12 +127,12 @@ class ViewController: UIViewController, ARSCNViewDelegate {
             treePosition.x = treePosition.x + (radius)*cos(2.0 * Float.pi / Float(amount) * Float(i))
             treePosition.z = treePosition.z - (radius)*sin(2.0 * Float.pi / Float(amount) * Float(i))
             
-            createPalmTree(position: treePosition, maxScale: 0.5, minScale: 0.2, delay: 0.05*Double(i))
+            createPalmTree(position: treePosition, maxScale: 0.5, minScale: 0.2, maxDelay: 3.0)
         }
     }
     
     // Creates a copy of the palm tree and randomizes the animation & rotation
-    func createPalmTree(position : SCNVector3, maxScale : Float, minScale: Float, delay: Double?) {
+    func createPalmTree(position : SCNVector3, maxScale : Float, minScale: Float, maxDelay: Double?) {
         // TODO: Randomize the palm tree's vertical rotation and the scale the trees grow to
         
         let allTrees = [palmNodes, pineNodes, treeNodes, trunkNodes]
@@ -160,7 +160,8 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         var palmSequence : SCNAction
         
         // If a delay amount has been passed, delay the sequence from starting. Otherwise, play normal sequence right away
-        if let delayAmt = delay {
+        if let maxDelayAmt = maxDelay {
+            let delayAmt = drand48() * maxDelayAmt
             delaySequence = SCNAction.wait(duration: delayAmt)
             palmSequence = SCNAction.sequence([
                     delaySequence,

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -127,7 +127,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
             treePosition.x = treePosition.x + (radius)*cos(2.0 * Float.pi / Float(amount) * Float(i))
             treePosition.z = treePosition.z - (radius)*sin(2.0 * Float.pi / Float(amount) * Float(i))
             
-            createPalmTree(position: treePosition, maxScale: 0.5, minScale: 0.2, maxDelay: 3.0)
+            createPalmTree(position: treePosition, maxScale: 0.5, minScale: 0.2, maxDelay: 1.0)
         }
     }
     
@@ -196,6 +196,6 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         let hitPosition = SCNVector3Make(hitTransform.m41, hitTransform.m42, hitTransform.m43)
         
         // Creates a palm tree at the location detected by touch
-        createPalmTreeRing(position: hitPosition, radius: 0.15, amount: 8)
+        createPalmTreeRing(position: hitPosition, radius: 0.25, amount: 8)
     }
 }

--- a/steps_of_the_forest_god/ViewController.swift
+++ b/steps_of_the_forest_god/ViewController.swift
@@ -144,13 +144,14 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         // Set scale of tree to 0
         palmClone.scale = SCNVector3Make(0, 0, 0)
         
-        // Animate tree to grow then shrink
+        // Play tree creation sound (TODO: Find a better sound)
         let audioSource = SCNAudioSource(fileNamed: "art.scnassets/tree_sound.mp3")
         let playSound = SCNAction.playAudio(audioSource!, waitForCompletion: false)
         
         // Calculate a random scale between the provided min and max scale
         let scaleAmt = CGFloat(drand48()) * CGFloat(maxScale - minScale) + CGFloat(minScale)
         
+        // Animate tree to grow then shrink
         let growPalmAction = SCNAction.scale(to: scaleAmt, duration: 0.5)
         let shrinkPalmAction = SCNAction.scale(to: 0, duration: 1.5)
 


### PR DESCRIPTION
Rings of trees grow more organically by having the delay for tree animations randomized

Trees will randomly scale to a size between a specified min and max

Refined parameters to create easier-to-see forest rings

Added feature where some trees will stick around after they've finished growing, thus leaving a trail of shrubbery as the user walks around 